### PR TITLE
Add Discard Audio by UI filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ configure_file(
 set(PLUGIN_SOURCES
 	src/plugin-main.c
 	src/mute-filter.c
+	src/mute-filter-by-ui.c
 )
 
 add_library(${PROJECT_NAME} MODULE ${PLUGIN_SOURCES})

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This plugin to mute audio of a source.
+This plugin will discard audio of a source.
 
 Even though a user muted a source in the mixer of OBS Studio,
 the source sometimes triggers OBS Studio to add more audio buffers.
@@ -10,6 +10,12 @@ the source sometimes triggers OBS Studio to add more audio buffers.
 adding 21 milliseconds of audio buffering, total audio buffering is now 85 milliseconds (source: cam3)
 ```
 It should not cause any problem but it's better to avoid unnecessary process.
+
+This plugin provides two filter types;
+1. Discard Audio --
+   This filter will just discard all audio data from the source.
+2. Discard Audio by UI --
+   This filter will discard audio data from the source while the source is muted in the mixer.
 
 ## Properties
 

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,0 +1,1 @@
+MuteByUI.Name="Discard Audio by UI"

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,1 +1,2 @@
+Mute.Name="Discard Audio"
 MuteByUI.Name="Discard Audio by UI"

--- a/src/mute-filter-by-ui.c
+++ b/src/mute-filter-by-ui.c
@@ -1,0 +1,98 @@
+#include <obs-module.h>
+#include "plugin-macros.generated.h"
+
+#define TS_SMOOTHING_THRESHOLD 70000000ULL
+
+struct mute_by_ui_s
+{
+	obs_source_t *ctx;
+
+	obs_weak_source_t *weak_parent;
+	bool configured;
+	volatile bool parent_muted;
+	bool last_muted;
+	uint64_t last_audio_ns;
+};
+
+static const char *get_name(void *type_data)
+{
+	UNUSED_PARAMETER(type_data);
+	return obs_module_text("MuteByUI.Name");
+}
+
+static void *create(obs_data_t *settings, obs_source_t *source)
+{
+	UNUSED_PARAMETER(settings);
+
+	struct mute_by_ui_s *m = bzalloc(sizeof(struct mute_by_ui_s));
+	m->ctx = source;
+
+	return m;
+}
+
+static void mute_cb(void *data, calldata_t *cd)
+{
+	struct mute_by_ui_s *m = data;
+	m->parent_muted = calldata_bool(cd, "muted");
+}
+
+static void configure_callback(struct mute_by_ui_s *m)
+{
+	obs_source_t *parent = obs_filter_get_parent(m->ctx);
+	if (!parent)
+		return;
+
+	signal_handler_t *sh = obs_source_get_signal_handler(parent);
+	signal_handler_connect(sh, "mute", mute_cb, m);
+
+	m->parent_muted = obs_source_muted(parent);
+	m->weak_parent = obs_source_get_weak_source(parent);
+
+	m->configured = true;
+}
+
+static void destroy(void *data)
+{
+	struct mute_by_ui_s *m = data;
+
+	if (m->configured) {
+		obs_source_t *parent = obs_weak_source_get_source(m->weak_parent);
+		signal_handler_t *sh = obs_source_get_signal_handler(parent);
+		signal_handler_disconnect(sh, "mute", mute_cb, m);
+		obs_source_release(parent);
+		obs_weak_source_release(m->weak_parent);
+	}
+
+	bfree(m);
+}
+
+static struct obs_audio_data *mute_filter_audio(void *data, struct obs_audio_data *audio)
+{
+	struct mute_by_ui_s *m = data;
+
+	if (!m->configured)
+		configure_callback(m);
+
+	if (m->parent_muted) {
+		m->last_muted = true;
+		return NULL;
+	}
+
+	if (m->last_muted && audio->timestamp - m->last_audio_ns < TS_SMOOTHING_THRESHOLD) {
+		return NULL;
+	}
+
+	m->last_muted = false;
+	m->last_audio_ns = audio->timestamp;
+	return audio;
+}
+
+const struct obs_source_info mute_filter_by_ui_info = {
+	.id = ID_PREFIX "mute-filter-by-ui",
+	.type = OBS_SOURCE_TYPE_FILTER,
+	.output_flags = OBS_SOURCE_AUDIO,
+	.get_name = get_name,
+	.create = create,
+	.destroy = destroy,
+	.filter_audio = mute_filter_audio,
+};

--- a/src/mute-filter.c
+++ b/src/mute-filter.c
@@ -4,7 +4,7 @@
 static const char *get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
-	return obs_module_text("Mute Audio");
+	return obs_module_text("Mute.Name");
 }
 
 static void *create(obs_data_t *settings, obs_source_t *source)

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -25,10 +25,12 @@ OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
 extern const struct obs_source_info mute_filter_info;
+extern const struct obs_source_info mute_filter_by_ui_info;
 
 bool obs_module_load(void)
 {
 	obs_register_source(&mute_filter_info);
+	obs_register_source(&mute_filter_by_ui_info);
 	blog(LOG_INFO, "plugin loaded (version %s)", PLUGIN_VERSION);
 	return true;
 }


### PR DESCRIPTION
### Motivation

To enable/disable the filter, it takes multiple clicks; right click the source, open its filter dialog, enable or disable the filter, close the filter dialog. It is not easily visible whether the filter is enabled or not.
When frequently changing the enable/disable state, I want a quick way to switch the filter and also visible.


### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This PR will add a new filter type "Discard Audio by UI", which will discard audio (the feature of the current Mute Filter) only while the attached source is muted by a user on the Mixer dock.

This PR also renames the existing filter type "Mute Audio" to "Discard Audio" because the word "Mute" is confusing with the "Mute" on the Mixer or the filter itself. The "Mute" on the mixer behaves differently from this filter so that a different name would be appropriate.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
OS: Fedora 38

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
